### PR TITLE
fix(deps): address Dependabot CVEs — pyOpenSSL, cryptography, requests, Pygments

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -6,6 +6,27 @@ This file documents detailed technical changes, internal refactorings, and devel
 
 ### Bug Fixes — Technical Details
 
+#### Dependency Security Upgrades — Dependabot CVE Remediation
+
+- **Scope**: 7 open Dependabot alerts in `requirements.txt`, covering 5 packages.
+- **Root cause for pyOpenSSL block**: `snowflake-connector-python<4.4.0` had an upper bound of `pyOpenSSL<26.0.0`,
+  preventing the CVE fix. `snowflake-connector-python==4.4.0` (released 2026-03) removed that upper bound and itself
+  bumped its minimum `cryptography` requirement to `>=46.0.5`.
+- **Changes**:
+  - `snowflake-connector-python>=4.4.0` (was `>=4.3.0`): lifts pyOpenSSL upper bound; resolves alerts #9 + #10.
+  - `snowflake-snowpark-python>=1.48.1` (was `>=1.45.0`): picks up latest Snowpark SDK improvements.
+  - `cryptography>=46.0.6` (was `>=46.0.5`): fixes SECT-curve subgroup attack (alert #3) and incomplete DNS
+    name constraint enforcement (alert #13).
+  - `requests>=2.33.0` (new pin): fixes insecure temp-file reuse in `extract_zipped_paths()` (alert #12).
+  - `pyOpenSSL>=26.0.0` (new pin, replaces BLOCKED comment): fixes DTLS cookie callback buffer overflow (alert
+    #10, HIGH) and TLS connection bypass via unhandled callback (alert #9, LOW).
+  - `Pygments>=2.20.0` (new pin): fixes ReDoS via inefficient GUID-matching regex (alert #14, LOW). Pygments
+    is a transitive dependency via `pytest` and `rich`.
+  - Retained existing `urllib3>=2.6.3` and `wheel>=0.46.2` pins (no new alerts; still protective).
+- **Protobuf alert #4**: advisory range is `>=6.30.0rc1,<=6.33.4` (6.x series only). Our pin `>=5.29.6,<6.0.0`
+  means we are on the patched 5.x series and not affected. Alert can be dismissed as "not applicable" on GitHub.
+- **Files changed**: `requirements.txt`
+
 #### Tasks Plugin — Timestamp Fields Converted to Epoch Nanoseconds (TI-001)
 
 - **Root cause**: `V_TASK_HISTORY` passed `th.SCHEDULED_TIME` and `th.COMPLETED_TIME` directly into the `ATTRIBUTES` OBJECT_CONSTRUCT without any conversion. Snowflake serialises `TIMESTAMP_LTZ` values as ISO 8601 datetime strings (e.g. `"2025-04-29 00:00:00.000 Z"`) inside a VARIANT/OBJECT. Every other timestamp attribute across all plugins uses `extract(epoch_nanosecond from ...)` — these two fields were the only exceptions. The `instruments-def.yml` `__example` values had been written to match the broken output rather than the intended contract.

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,8 +78,9 @@ jaraco-context>=6.1.0
 # CVE-2026-25990: Pillow buffer overflow
 pillow>=12.1.1
 # CVE-2026-0994: Protobuf DoS in json_format.ParseDict()
-# Using 5.x branch to maintain compatibility with snowflake-snowpark-python
-protobuf>=5.29.6,<6.0.0
+# snowflake-snowpark-python>=1.48.1 allows protobuf<6.34; opentelemetry-proto==1.39.1 allows protobuf<7.0
+# Upper bound <6.34 matches snowpark's constraint; lower bound covers both patched 5.x (5.29.6) and 6.x (6.33.5+)
+protobuf>=5.29.6,<6.34
 # CVE-2025-21613: Requests insecure temp file reuse in extract_zipped_paths()
 requests>=2.33.0
 # CVE-2026-27459 (GHSA-5pwr-322w-8jr4) HIGH: pyOpenSSL DTLS cookie callback buffer overflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,9 +78,10 @@ jaraco-context>=6.1.0
 # CVE-2026-25990: Pillow buffer overflow
 pillow>=12.1.1
 # CVE-2026-0994: Protobuf DoS in json_format.ParseDict()
-# snowflake-snowpark-python>=1.48.1 allows protobuf<6.34; opentelemetry-proto==1.39.1 allows protobuf<7.0
-# Upper bound <6.34 matches snowpark's constraint; lower bound covers both patched 5.x (5.29.6) and 6.x (6.33.5+)
-protobuf>=5.29.6,<6.34
+# Advisory range: >=6.30.0rc1,<=6.33.4. Fixed in 6.33.5+.
+# snowflake-snowpark-python>=1.48.1 caps at <6.34; opentelemetry-proto==1.39.1 allows <7.0; streamlit allows <7.
+# Pin to >=6.33.5,<6.34 to land on the patched 6.x release within the tightest transitive constraint.
+protobuf>=6.33.5,<6.34
 # CVE-2025-21613: Requests insecure temp file reuse in extract_zipped_paths()
 requests>=2.33.0
 # CVE-2026-27459 (GHSA-5pwr-322w-8jr4) HIGH: pyOpenSSL DTLS cookie callback buffer overflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,8 @@
 # IMPORTANT: Requires Python >=3.9 and <3.12 (due to snowflake-legacy dependency)
 snowflake>=1.11.0
 snowflake-core==1.11.0
-snowflake-snowpark-python>=1.45.0
-snowflake-connector-python[secure-local-storage]>=4.3.0
+snowflake-snowpark-python>=1.48.1
+snowflake-connector-python[secure-local-storage]>=4.4.0
 streamlit
 
 # === OpenTelemetry ===
@@ -67,7 +67,8 @@ weasyprint
 # CVE-2025-6176: Brotli DoS vulnerability
 brotli>=1.2.0
 # CVE-2026-26007: Cryptography SECT curve validation issue
-cryptography>=46.0.5
+# CVE-2026-28100: Cryptography incomplete DNS name constraint enforcement
+cryptography>=46.0.6
 # CVE-2025-68146, CVE-2026-22701: Filelock race condition
 filelock>=3.20.3
 # CVE-2025-66034: Fonttools buffer overflow
@@ -79,14 +80,18 @@ pillow>=12.1.1
 # CVE-2026-0994: Protobuf DoS in json_format.ParseDict()
 # Using 5.x branch to maintain compatibility with snowflake-snowpark-python
 protobuf>=5.29.6,<6.0.0
+# CVE-2025-21613: Requests insecure temp file reuse in extract_zipped_paths()
+requests>=2.33.0
+# CVE-2026-27459 (GHSA-5pwr-322w-8jr4) HIGH: pyOpenSSL DTLS cookie callback buffer overflow
+# CVE-2026-27448 (GHSA-vp96-hxj8-p424) LOW: pyOpenSSL TLS connection bypass via unhandled callback
+# Unblocked by snowflake-connector-python>=4.4.0 which removed the pyOpenSSL upper bound
+pyOpenSSL>=26.0.0
+# CVE-2025-28091: Pygments ReDoS via inefficient regex for GUID matching
+Pygments>=2.20.0
 # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441: urllib3 security issues
 urllib3>=2.6.3
 # CVE-2026-24049: Wheel path traversal vulnerability
 wheel>=0.46.2
-# CVE-2026-27459 (GHSA-5pwr-322w-8jr4) HIGH: pyOpenSSL DTLS cookie callback buffer overflow
-# CVE-2026-27448 (GHSA-vp96-hxj8-p424) LOW: pyOpenSSL TLS connection bypass via unhandled callback
-# BLOCKED: snowflake-connector-python>=4.3.0 pins pyOpenSSL<26.0.0 — cannot upgrade until Snowflake lifts the bound
-# Track: https://github.com/snowflakedb/snowflake-connector-python for a release with pyOpenSSL>=26.0.0
 
 # dependencies
 chardet>=3.0.2,<6.0.0


### PR DESCRIPTION
## Summary

Addresses all 7 open Dependabot alerts in `requirements.txt`.

## Changes

| Package | Before | After | Alerts closed |
|---|---|---|---|
| `snowflake-connector-python` | `>=4.3.0` | `>=4.4.0` | Unblocks pyOpenSSL upgrade |
| `snowflake-snowpark-python` | `>=1.45.0` | `>=1.48.1` | Latest SDK |
| `cryptography` | `>=46.0.5` | `>=46.0.6` | #3 (HIGH), #13 (LOW) |
| `requests` | _(unpinned)_ | `>=2.33.0` | #12 (MEDIUM) |
| `pyOpenSSL` | _(BLOCKED comment)_ | `>=26.0.0` | #9 (LOW), #10 (HIGH) |
| `Pygments` | _(unpinned)_ | `>=2.20.0` | #14 (LOW) |
| `protobuf` | `>=5.29.6,<6.0.0` | `>=6.33.5,<6.34` | #4 (MODERATE) |

## Root Cause for pyOpenSSL Block

`snowflake-connector-python<4.4.0` enforced `pyOpenSSL<26.0.0`. Version 4.4.0 (2026-03) removed that upper bound, allowing `pyOpenSSL>=26.0.0` to be resolved.

## Protobuf Alert #4

Advisory range is `>=6.30.0rc1,<=6.33.4`. Fixed in `6.33.5+`. The upper bound `<6.34` is dictated by `snowflake-snowpark-python>=1.48.1`; `opentelemetry-proto==1.39.1` and `streamlit` both allow up to `<7.0`, so `6.33.5`–`6.33.x` is fully compatible. Tested with `6.33.6`.

## Validation

- `make lint` — clean (pylint 10.00/10, black, flake8, sqlfluff, markdownlint, yamllint)
- `pytest test/core test/otel` — 132 passed, 3 skipped (pre-existing hang in `test_deployment_scripts` excluded)