### PR TITLE
feat: add long-running queries Davis AD workflow [A1]

### DIFF
--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -87,6 +87,7 @@ dtctl apply -f /tmp/workflow-apply.json
 | [Dynamic Table Refresh Drift Detection](./dynamic-table-drift/readme.md)      | Quality / Performance | Detects when dynamic table scheduling lag consistently exceeds target lag                      | `dynamic_tables`    |
 | [Query Slowdown Detection](./query-slowdown-detection/readme.md)              | Performance           | Detects abnormal increases in query execution time per warehouse and database                  | `query_history`     |
 | [Table Performance Degradation Detection](./table-perf-degradation/readme.md) | Performance           | Detects tables with rising partition scan ratios indicating need for re-clustering             | `query_history`     |
+| [Long-Running Queries Detection](./long-running-queries/readme.md)            | Performance           | Detects individual queries with abnormal max execution time per warehouse and user             | `query_history`     |
 
 ## Workflow Structure
 

--- a/docs/workflows/long-running-queries/long-running-queries.yml
+++ b/docs/workflows/long-running-queries/long-running-queries.yml
@@ -125,9 +125,7 @@ tasks:
       x: 0
       y: 2
     conditions:
-      states:
-        ad_long_running_by_warehouse: OK
-        ad_long_running_by_user: OK
+      states: {}
     predecessors:
       - ad_long_running_by_warehouse
       - ad_long_running_by_user

--- a/docs/workflows/long-running-queries/long-running-queries.yml
+++ b/docs/workflows/long-running-queries/long-running-queries.yml
@@ -1,0 +1,278 @@
+# WORKFLOW: DSOA — Long-Running Queries Detection
+# DESCRIPTION: Detects individual queries with abnormal max execution time per warehouse and user using Davis AI
+# OWNER: DSOA Team
+# PLUGINS: query_history
+# TAGS: snowflake, dsoa, performance, query-history
+
+id: c3f7a2b1-84d0-4e9a-b5c6-1d2e8f0a3b47
+title: "DSOA — Long-Running Queries Detection"
+description: |
+  Monitors maximum query execution time per warehouse and per user using Davis AI anomaly detection.
+  Alerts when max execution time significantly exceeds the learned seasonal baseline — detecting
+  individual long-running queries that would be invisible to average-based detectors. Only successful
+  queries are analyzed to avoid noise from failed executions. Requires the query_history plugin.
+isPrivate: false
+schemaVersion: 4
+trigger:
+  schedule:
+    isActive: true
+    trigger:
+      type: interval
+      intervalMinutes: 360
+    rule: null
+    filterParameters: {}
+    timezone: UTC
+    inputs: {}
+tasks:
+  ad_long_running_by_warehouse:
+    name: ad_long_running_by_warehouse
+    description: Detect max query execution time anomalies per warehouse using Davis AI
+    action: dynatrace.davis.workflow.actions:davis-analyze
+    active: true
+    position:
+      x: -1
+      y: 1
+    conditions:
+      states: {}
+    predecessors: []
+    input:
+      analyzerName: dt.statistics.anomaly_detection.SeasonalBaselineAnomalyDetectionAnalyzer
+      body:
+        timeSeriesData: |
+          timeseries max_exec = max(snowflake.time.execution)
+          , by: {
+            snowflake.warehouse.name,
+            deployment.environment
+          }
+          , filter: {
+            snowflake.query.execution_status == "SUCCESS"
+          }
+          // Optional: restrict to specific warehouses
+          // | filter in(snowflake.warehouse.name, "COMPUTE_WH", "ANALYTICS_WH")
+          // Optional: restrict to a specific environment
+          // | filter deployment.environment == "prod"
+          | fieldsAdd
+              metric_name = "snowflake.query.execution_time.max",
+              _event_name_template = "Long-running query detected in warehouse {dims:snowflake.warehouse.name}",
+              _event_description_template = "Max query execution time in warehouse {dims:snowflake.warehouse.name} ({dims:deployment.environment}) has significantly exceeded the learned baseline, indicating an individual long-running query."
+        alertCondition: ABOVE
+        tolerance: 3
+        generalParameters:
+          timeframe:
+            startTime: now()-30d
+            endTime: now
+          logVerbosity: WARNING
+          resolveDimensionalQueryData: false
+        slidingWindow: 3
+        violatingSamples: 2
+        dealertingSamples: 3
+        alertOnMissingData: false
+        useModelCache: true
+        extendedOutput: false
+
+  ad_long_running_by_user:
+    name: ad_long_running_by_user
+    description: Detect max query execution time anomalies per user using Davis AI
+    action: dynatrace.davis.workflow.actions:davis-analyze
+    active: true
+    position:
+      x: 1
+      y: 1
+    conditions:
+      states: {}
+    predecessors: []
+    input:
+      analyzerName: dt.statistics.anomaly_detection.SeasonalBaselineAnomalyDetectionAnalyzer
+      body:
+        timeSeriesData: |
+          timeseries max_exec = max(snowflake.time.execution)
+          , by: {
+            db.user,
+            deployment.environment
+          }
+          , filter: {
+            snowflake.query.execution_status == "SUCCESS"
+          }
+          // Optional: restrict to specific users
+          // | filter in(db.user, "ANALYST", "ETL_USER")
+          // Optional: restrict to a specific environment
+          // | filter deployment.environment == "prod"
+          | fieldsAdd
+              metric_name = "snowflake.query.execution_time.max",
+              _event_name_template = "Long-running query detected for user {dims:db.user}",
+              _event_description_template = "Max query execution time for user {dims:db.user} ({dims:deployment.environment}) has significantly exceeded the learned baseline, indicating an individual long-running query."
+        alertCondition: ABOVE
+        tolerance: 3
+        generalParameters:
+          timeframe:
+            startTime: now()-30d
+            endTime: now
+          logVerbosity: WARNING
+          resolveDimensionalQueryData: false
+        slidingWindow: 3
+        violatingSamples: 2
+        dealertingSamples: 3
+        alertOnMissingData: false
+        useModelCache: true
+        extendedOutput: false
+
+  extract_anomaly_events:
+    name: extract_anomaly_events
+    description: Process Davis results from both analyzers and build Dynatrace event objects
+    action: dynatrace.automations:run-javascript
+    active: true
+    position:
+      x: 0
+      y: 2
+    conditions:
+      states:
+        ad_long_running_by_warehouse: OK
+        ad_long_running_by_user: OK
+    predecessors:
+      - ad_long_running_by_warehouse
+      - ad_long_running_by_user
+    input:
+      script: |
+        import { execution } from '@dynatrace-sdk/automation-utils';
+        import { EventIngestEventType } from '@dynatrace-sdk/client-classic-environment-v2';
+
+        // === CONFIGURATION ===
+        // Change eventType to EventIngestEventType.CustomAlert to enable Davis problem correlation.
+        // CustomInfo (default) creates informational events without triggering Davis problems.
+        const CONFIG = {
+          eventType: EventIngestEventType.CustomInfo,
+          eventTimeout: 360,
+          adSource: 'dsoa.long_running_queries'
+        };
+        // === END CONFIGURATION ===
+
+        function replacePlaceholders(contentString, data) {
+          const pattern = /\{dims:(\S*?)}/gm;
+          let matches = [];
+          while ((matches = pattern.exec(contentString))) {
+            contentString = contentString.replace(matches[0], data[matches[1]]);
+          }
+          return contentString;
+        }
+
+        function unpackMap(amap) {
+          const mappedResult = {};
+          amap.forEach(item => {
+            mappedResult[item.key] = item.value;
+          });
+          return mappedResult;
+        }
+
+        function createEventObject(alert, result, events) {
+          const startTime = alert.timeframe.startTime;
+          const endTime = alert.timeframe.endTime;
+          const eventTitle = result.dimensions.find(x => x.key === '_event_name_template')?.value;
+          const eventDesc = result.dimensions.find(x => x.key === '_event_description_template')?.value;
+          const sourceMetric = result.dimensions.find(x => x.key === 'metric_name')?.value;
+          const resultDimensions = unpackMap(result.dimensions);
+
+          const newEvent = {
+            body: {
+              eventType: CONFIG.eventType,
+              title: replacePlaceholders(eventTitle, resultDimensions),
+              properties: {
+                'event.description': replacePlaceholders(eventDesc, resultDimensions)
+              },
+              timeout: CONFIG.eventTimeout
+            }
+          };
+
+          newEvent.body.properties['event.start'] = startTime;
+          newEvent.body.properties['event.end'] = endTime;
+          newEvent.body.properties['ad.source'] = CONFIG.adSource;
+          newEvent.body.properties['ad.source_metric'] = sourceMetric;
+          newEvent.body.properties['ad.direction'] = 'above';
+
+          if (result.dimensions.length > 0) {
+            result.dimensions.forEach(dim => {
+              if (!dim.key.startsWith('_')) {
+                newEvent.body.properties[dim.key] = dim.value;
+              }
+            });
+          }
+          events.push(newEvent);
+        }
+
+        export default async function ({ execution_id }) {
+          const ex = await execution(execution_id);
+
+          const events = [];
+          for (const taskName of ['ad_long_running_by_warehouse', 'ad_long_running_by_user']) {
+            let analyzerResult;
+            try {
+              analyzerResult = await ex.result(taskName);
+            } catch (e) {
+              console.log(`Skipping ${taskName}: ${e.message}`);
+              continue;
+            }
+            if (analyzerResult && analyzerResult.output && analyzerResult.output.length > 0) {
+              analyzerResult.output.forEach(result => {
+                if (result.raisedAlerts && result.raisedAlerts.length > 0) {
+                  result.raisedAlerts.forEach(alert => {
+                    createEventObject(alert, result, events);
+                  });
+                }
+              });
+            }
+          }
+
+          console.log(`Extracted ${events.length} anomaly event(s)`);
+          return events;
+        }
+
+  ingest_anomaly_events:
+    name: ingest_anomaly_events
+    description: Ingest anomaly events via Dynatrace Environment V2 API
+    action: dynatrace.automations:run-javascript
+    active: true
+    position:
+      x: 0
+      y: 3
+    conditions:
+      states:
+        extract_anomaly_events: OK
+    predecessors:
+      - extract_anomaly_events
+    input:
+      script: |
+        import { execution } from '@dynatrace-sdk/automation-utils';
+        import { eventsClient } from '@dynatrace-sdk/client-classic-environment-v2';
+
+        async function ingestEvents(events) {
+          let successCount = 0;
+          const failed = [];
+          for (let i = 0; i < events.length; ++i) {
+            const res = await eventsClient.createEvent(events[i]);
+            if (res.reportCount !== 1) {
+              failed.push({ reason: 'Invalid number of ingested events' });
+            } else {
+              const status = res.eventIngestResults[0];
+              if (status.status === 'OK') {
+                successCount += 1;
+              } else {
+                failed.push(JSON.stringify(status));
+              }
+            }
+          }
+          if (successCount === 0 && failed.length === 0) {
+            console.log('No events to ingest');
+          }
+          if (successCount > 0) {
+            console.log(`Successfully ingested ${successCount} event(s)`);
+          }
+          if (failed.length > 0) {
+            console.log(`Failed to ingest ${failed.length} event(s):`, JSON.stringify(failed));
+          }
+        }
+
+        export default async function ({ execution_id }) {
+          const ex = await execution(execution_id);
+          const events = await ex.result('extract_anomaly_events');
+          await ingestEvents(events);
+          return events;
+        }

--- a/docs/workflows/long-running-queries/readme.md
+++ b/docs/workflows/long-running-queries/readme.md
@@ -47,14 +47,15 @@ ad_long_running_by_user      ─┘
    pattern (including weekly seasonality) and raises an alert when the max rises significantly above
    that baseline. Only `SUCCESS` queries are included.
 
-2. **`ad_long_running_by_user`** — Identical analysis grouped by `db.user` instead of warehouse,
+1. **`ad_long_running_by_user`** — Identical analysis grouped by `db.user` instead of warehouse,
    catching users whose queries suddenly run much longer than their personal baseline.
 
-3. **`extract_anomaly_events`** — Fan-in task: collects raised alerts from both analyzers, builds
-   Dynatrace event payloads with all relevant dimensions attached as event properties. Continues
-   even if one analyzer task fails (`OK` condition) so partial results are never lost.
+1. **`extract_anomaly_events`** — Fan-in task: collects raised alerts from both analyzers, builds
+   Dynatrace event payloads with all relevant dimensions attached as event properties. Waits for
+   both predecessors via `predecessors`, then JS try/catch skips any failed task so partial results
+   are never lost.
 
-4. **`ingest_anomaly_events`** — Sends each event to Dynatrace via the Environment V2 Events API.
+1. **`ingest_anomaly_events`** — Sends each event to Dynatrace via the Environment V2 Events API.
 
 ## Telemetry Source
 

--- a/docs/workflows/long-running-queries/readme.md
+++ b/docs/workflows/long-running-queries/readme.md
@@ -1,0 +1,136 @@
+# Workflow: Long-Running Queries Detection
+
+Monitors maximum query execution time per warehouse and per user using Davis AI anomaly detection.
+Fires an event when max execution time significantly exceeds the learned seasonal baseline,
+detecting individual long-running queries that would be invisible to average-based detectors.
+Only successful queries are analyzed to avoid noise from failed executions.
+
+## Overview
+
+| Property        | Value                                        |
+|-----------------|----------------------------------------------|
+| DPO Theme       | Performance                                  |
+| Required Plugin | `query_history`                              |
+| Trigger         | Every 6 hours (interval)                     |
+| Alert condition | ABOVE baseline (rising max execution time)   |
+| Tolerance       | 3 (higher than avg-based; max() is spikier)  |
+| Event source    | `dsoa.long_running_queries`                  |
+
+## Relationship to Other Approaches
+
+DSOA provides three complementary approaches to long-running query detection. Use all three
+together for complete coverage:
+
+| Approach                              | Timing     | Detection scope              | Metric                   |
+|---------------------------------------|------------|------------------------------|--------------------------|
+| `active_queries` plugin               | Real-time  | Individual running queries   | Configurable threshold   |
+| `query-slowdown-detection` workflow   | Post-hoc   | Per-warehouse + per-database | `avg(execution_time)`    |
+| **This workflow** (long-running)      | Post-hoc   | Per-warehouse + per-user     | `max(execution_time)`    |
+
+- **`active_queries`**: catches queries _while they run_ but requires Snowflake API access and
+  may miss short spikes.
+- **`query-slowdown-detection`**: detects warehouse-level degradation trends; `avg()` suppresses
+  individual outliers by design.
+- **This workflow**: detects outlier queries _after_ completion; `max()` surfaces a single
+  anomalous query even when the warehouse average looks healthy.
+
+## How It Works
+
+```text
+ad_long_running_by_warehouse ─┐
+                               ├─> extract_anomaly_events ──> ingest_anomaly_events
+ad_long_running_by_user      ─┘
+```
+
+1. **`ad_long_running_by_warehouse`** — Davis AI (`SeasonalBaselineAnomalyDetectionAnalyzer`) runs
+   against a time-series of max execution time per warehouse. It learns the typical max-duration
+   pattern (including weekly seasonality) and raises an alert when the max rises significantly above
+   that baseline. Only `SUCCESS` queries are included.
+
+2. **`ad_long_running_by_user`** — Identical analysis grouped by `db.user` instead of warehouse,
+   catching users whose queries suddenly run much longer than their personal baseline.
+
+3. **`extract_anomaly_events`** — Fan-in task: collects raised alerts from both analyzers, builds
+   Dynatrace event payloads with all relevant dimensions attached as event properties. Continues
+   even if one analyzer task fails (`OK` condition) so partial results are never lost.
+
+4. **`ingest_anomaly_events`** — Sends each event to Dynatrace via the Environment V2 Events API.
+
+## Telemetry Source
+
+Queries the `snowflake.time.execution` metric from the `query_history` plugin:
+
+| Field                              | Role                                    |
+|------------------------------------|-----------------------------------------|
+| `snowflake.warehouse.name`         | Dimension (per-warehouse series)        |
+| `db.user`                          | Dimension (per-user series)             |
+| `snowflake.time.execution`         | Metric (query execution time in ms)     |
+| `snowflake.query.execution_status` | Filter (`SUCCESS` queries only)         |
+| `deployment.environment`           | Dimension (environment scope)           |
+
+## Event Properties
+
+Each ingested event carries:
+
+| Property                   | Value                                        |
+|----------------------------|----------------------------------------------|
+| `event.type`               | `CustomInfo` (default)                       |
+| `ad.source`                | `dsoa.long_running_queries`                  |
+| `ad.source_metric`         | `snowflake.query.execution_time.max`         |
+| `ad.direction`             | `above`                                      |
+| `event.start/end`          | Anomaly timeframe from Davis                 |
+| `snowflake.warehouse.name` | Affected warehouse (warehouse analyzer only) |
+| `db.user`                  | Affected user (user analyzer only)           |
+| `deployment.environment`   | Snowflake environment                        |
+
+## Customization
+
+At the top of the `extract_anomaly_events` task there is a `CONFIG` block:
+
+```js
+const CONFIG = {
+  eventType: EventIngestEventType.CustomInfo,   // change to CustomAlert for Davis problems
+  eventTimeout: 360,
+  adSource: 'dsoa.long_running_queries'
+};
+```
+
+- **`eventType`**: Switch to `EventIngestEventType.CustomAlert` to enable Davis problem
+  correlation and receive problem notifications.
+- **`eventTimeout`**: Event lifetime in minutes before auto-close (default: 360 = 6 h).
+
+The Davis analyzer tasks also expose tunable parameters:
+
+| Parameter          | Default | Effect                                                          |
+|--------------------|---------|-----------------------------------------------------------------|
+| `tolerance`        | `3`     | Sensitivity — lower catches more anomalies, higher reduces FPs  |
+| `slidingWindow`    | `3`     | Number of consecutive intervals evaluated as a window           |
+| `violatingSamples` | `2`     | Intervals within the window that must violate to raise an alert |
+| `dealertingSamples`| `3`     | Intervals that must recover before closing an alert             |
+| `intervalMinutes`  | `360`   | Workflow trigger frequency; increase to reduce API load         |
+
+### Scoping Analyzers
+
+Both analyzer tasks include commented-out `| filter` lines for scoping:
+
+```dql
+// Warehouse analyzer — restrict to specific warehouses:
+| filter in(snowflake.warehouse.name, "COMPUTE_WH", "ANALYTICS_WH")
+
+// User analyzer — restrict to specific users:
+| filter in(db.user, "ANALYST", "ETL_USER")
+
+// Either analyzer — restrict to a specific environment:
+| filter deployment.environment == "prod"
+```
+
+Uncomment and adjust these filters directly in the workflow YAML before deploying.
+
+## Prerequisites
+
+- `query_history` plugin enabled and collecting telemetry.
+- At least 7 days of history for meaningful baselines (14 days recommended for seasonal learning).
+
+## Screenshots
+
+<!-- Add screenshots after deployment -->


### PR DESCRIPTION
Two SeasonalBaselineAnomalyDetectionAnalyzer tasks (per-warehouse, per-user) detect individual outlier queries via max(execution_time) — the gap left by the avg-based query-slowdown-detection workflow. Fan-in extract step survives a single analyzer failure (OK condition).
