### PR TITLE
fix: set Python artifact repository

### DIFF
--- a/src/dtagent.sql/agents/700_dtagent.sql
+++ b/src/dtagent.sql/agents/700_dtagent.sql
@@ -36,6 +36,7 @@ create or replace procedure DTAGENT_DB.APP.DTAGENT(sources array)
 returns object
 language python
 runtime_version = '3.13'
+artifact_repository = snowflake.snowpark.anaconda_shared_repository
 packages = (
     'requests',
     'pandas',

--- a/src/dtagent.sql/agents/701_p_send_telemetry.sql
+++ b/src/dtagent.sql/agents/701_p_send_telemetry.sql
@@ -30,6 +30,7 @@ create or replace procedure DTAGENT_DB.APP.SEND_TELEMETRY(sources variant, param
 returns string
 language python
 runtime_version = '3.13'
+artifact_repository = snowflake.snowpark.anaconda_shared_repository
 packages = (
     'requests',
     'pandas',

--- a/src/dtagent/version.py
+++ b/src/dtagent/version.py
@@ -29,7 +29,7 @@
 
 ##region --------------------------- VERSION INFO ------------------------------------
 
-VERSION = "1.0.0"
+VERSION = "1.0.0.1"
 BUILD = 0
 
 ##endregion

--- a/test/_mocks/telemetry.py
+++ b/test/_mocks/telemetry.py
@@ -25,11 +25,9 @@ import os
 import json
 import re
 import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch, Mock
-
-from git import Union
 
 from dtagent.context import RUN_ID_KEY, RUN_RESULTS_KEY
 


### PR DESCRIPTION
Set Python artifact repository in response to a change in the default repository in Snowflake (see Snowflake's BCR-2325).