### PR TITLE
fix: use default events_view when appropriate

### DIFF
--- a/src/dtagent.sql/init/001_viewer_role.sql
+++ b/src/dtagent.sql/init/001_viewer_role.sql
@@ -33,6 +33,15 @@ grant MONITOR EXECUTION on ACCOUNT to role DTAGENT_VIEWER;
 
 grant MODIFY SESSION LOG LEVEL on ACCOUNT to role DTAGENT_VIEWER;
 grant IMPORTED PRIVILEGES on database SNOWFLAKE to role DTAGENT_VIEWER;
+execute immediate
+    $$
+begin
+    grant application role SNOWFLAKE.EVENTS_VIEWER to role DTAGENT_VIEWER;
+exception
+    when other then
+        SYSTEM$LOG_WARN(concat('Could not grant application role SNOWFLAKE.EVENTS_VIEWER to role DTAGENT_VIEWER: ', SQLERRM));
+end;
+$$;
 
 grant EXECUTE TASK on ACCOUNT to role DTAGENT_VIEWER;
 

--- a/src/dtagent/plugins/event_log.sql/init/009_event_log_init.sql
+++ b/src/dtagent/plugins/event_log.sql/init/009_event_log_init.sql
@@ -60,7 +60,7 @@ BEGIN
   -- Step 0: Read current account and schema state
   show PARAMETERS like 'EVENT_TABLE' in ACCOUNT;
   select "value" into s_account_et from TABLE(result_scan(last_query_id()));
-  IF (lower(:s_account_et) = 'snowflake.telemetry.events') THEN
+  IF (upper(:s_account_et) = 'SNOWFLAKE.TELEMETRY.EVENTS') THEN
     s_account_et := 'SNOWFLAKE.TELEMETRY.EVENTS_VIEW';
   END IF;
 

--- a/src/dtagent/plugins/event_log.sql/init/009_event_log_init.sql
+++ b/src/dtagent/plugins/event_log.sql/init/009_event_log_init.sql
@@ -60,6 +60,9 @@ BEGIN
   -- Step 0: Read current account and schema state
   show PARAMETERS like 'EVENT_TABLE' in ACCOUNT;
   select "value" into s_account_et from TABLE(result_scan(last_query_id()));
+  IF (lower(:s_account_et) = 'snowflake.telemetry.events') THEN
+    s_account_et := 'SNOWFLAKE.TELEMETRY.EVENTS_VIEW';
+  END IF;
 
   -- Detect whether LOG_EVENT_LEVEL parameter is supported (Snowflake BCR Bundle 2026_02+).
   BEGIN


### PR DESCRIPTION
Added a grant allowing access to `SNOWFLAKE.TELEMETRY.EVENTS_VIEW`.

Using the `EVENTS_VIEW` if `snowflake.telemetry.events` is the account event table.